### PR TITLE
fix: resolve home page image loading issue on Netlify

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -157,9 +157,10 @@ export default defineNuxtConfig({
     }
   },
   image: {
-    provider: process.env.NODE_ENV === 'production' ? 'netlify' : 'ipx',
+    provider: 'ipx',
+    domains: ['danvega.dev', 'www.danvega.dev'],
     netlify: {
-      baseURL: process.env.IMAGES_URL
+      baseURL: process.env.IMAGES_URL || process.env.NUXT_PUBLIC_SITE_URL || 'https://danvega.dev'
     }
   },
   sitemap: {


### PR DESCRIPTION
- Changed Nuxt Image provider from conditional Netlify to always use 'ipx'
- Added fallback baseURL configuration for Netlify provider
- Added domains configuration for production domain support
- This ensures consistent image loading behavior between development and production

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)