### PR TITLE
Adding Porto Tech Hub 2026 opening keynote

### DIFF
--- a/assets/data/events.json
+++ b/assets/data/events.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "Fundamentals of Software Engineering in the Age of AI (Opening Keynote)",
+    "url": "https://portotechhub.com/conference-2026/",
+    "slug": "porto-tech-hub-2026-fundamentals-software-engineering-ai",
+    "name": "Porto Tech Hub Conference 2026",
+    "startDate": "Nov 10, 2026",
+    "endDate": "Nov 10, 2026",
+    "location": "Porto, Portugal",
+    "description": "Every few years, something comes along that's supposed to end software engineering as we know it. IDE features that write code for you. Low-code. No-code. Now AI. And every time, the role adapts, the fundamentals stay, and the people who understand the craft come out ahead.\n\nStill, the anxiety this time around is real. The headlines say software engineering is dead. Your group chat says juniors are cooked. Your CEO just asked why the team isn't shipping 10x faster. Take a breath, because nobody knows where we are heading, but it's worth talking about honestly.\n\nHere's something you've probably noticed. AI is amazing at the things you don't know. Ask it about a language you've never touched or a framework you're just picking up, and it looks like magic. Then you ask it about the code you've lived in for five years, and suddenly you're catching mistakes on every other line. That's not a bug in the tool. That's the fundamentals talking. AI tools are genuinely powerful, and they reward the developers who already understand what good software looks like. Naming things well, knowing when to refactor, reading code critically, designing systems that hold up. These fundamentals matter more now, not less, because they're what let you tell when the output is wrong.\n\nWhether you write code, ship it, or plan the work around it, Dan Vega and Nate Schutta will cut through the noise around AI coding tools: where they help, where they hurt, and why the fundamentals are your biggest advantage right now. You'll leave knowing what to invest in, what to keep learning, and why the craft still matters."
+  },
+  {
     "title": "AI for Java Developers",
     "url": "https://www.meetup.com/pdxjug/events/315597761/",
     "name": "Portland Java User Group",

--- a/content/speaking/porto-tech-hub-2026-fundamentals-software-engineering-ai.md
+++ b/content/speaking/porto-tech-hub-2026-fundamentals-software-engineering-ai.md
@@ -1,0 +1,31 @@
+---
+slug: porto-tech-hub-2026-fundamentals-software-engineering-ai
+title: "Fundamentals of Software Engineering in the Age of AI"
+published: true
+date: "2026-11-10"
+conference: Porto Tech Hub Conference 2026
+conferenceUrl: https://portotechhub.com/conference-2026/
+location: Porto, Portugal
+description: "The opening keynote at Porto Tech Hub, where Dan Vega and Nate Schutta cut through the noise around AI coding tools and make the case for the fundamentals."
+---
+
+The opening keynote at Porto Tech Hub Conference 2026, presented with [Nate Schutta](https://www.ntschutta.io/).
+
+Every few years, something comes along that's supposed to end software engineering as we know it. IDE features that write code for you. Low-code. No-code. Now AI. And every time, the role adapts, the fundamentals stay, and the people who understand the craft come out ahead.
+
+Still, the anxiety this time around is real. The headlines say software engineering is dead. Your group chat says juniors are cooked. Your CEO just asked why the team isn't shipping 10x faster. Take a breath, because nobody knows where we are heading, but it's worth talking about honestly.
+
+Here's something you've probably noticed. AI is amazing at the things you don't know. Ask it about a language you've never touched or a framework you're just picking up, and it looks like magic. Then you ask it about the code you've lived in for five years, and suddenly you're catching mistakes on every other line. That's not a bug in the tool. That's the fundamentals talking.
+
+AI tools are genuinely powerful, and they reward the developers who already understand what good software looks like. Naming things well, knowing when to refactor, reading code critically, designing systems that hold up. These fundamentals matter more now, not less, because they're what let you tell when the output is wrong.
+
+Whether you write code, ship it, or plan the work around it, we will cut through the noise around AI coding tools: where they help, where they hurt, and why the fundamentals are your biggest advantage right now.
+
+## What You'll Learn
+
+- Why the fundamentals matter more in an AI-assisted workflow, not less
+- Where AI coding tools genuinely help and where they quietly hurt
+- How to read and validate AI-generated code critically
+- The core skills worth investing in right now
+- What to keep learning as the tools keep changing
+- Why the craft still matters


### PR DESCRIPTION
Accepted to give the opening keynote at Porto Tech Hub Conference 2026 with Nate Schutta.

- **Talk:** Fundamentals of Software Engineering in the Age of AI
- **Date:** Nov 10, 2026
- **Venue:** Alfândega do Porto, Porto, Portugal

Adds the `events.json` entry and the `/speaking/porto-tech-hub-2026-fundamentals-software-engineering-ai` detail page. Both pages verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)